### PR TITLE
support for adding parameters to fieldDef for generate sequences

### DIFF
--- a/lib/backend-plus.js
+++ b/lib/backend-plus.js
@@ -958,6 +958,7 @@ AppBackend.prototype.dumpDbSchema = function dumpDbSchema(){
     contextForDump.user[be.config.login.rolFieldName]='admin';
     for(var tableName in be.tableStructures){
         var tableDef=be.tableStructures[tableName](contextForDump);
+        var fieldsForSequences=[];
         if(tableDef.sql.isTable){
             lines.push('create table '+db.quoteObject(tableDef.name)+' (');
             var fields=[];
@@ -973,6 +974,9 @@ AppBackend.prototype.dumpDbSchema = function dumpDbSchema(){
                         (fieldDef.nullable===false?' NOT NULL':'')+
                         (fieldDef.defaultValue!=null?' default '+db.quoteText(fieldDef.defaultValue):'')
                     );
+                }
+                if(fieldDef.generateSequence){
+                    fieldsForSequences.push(fieldDef);
                 }
             });
             lines.push(fields.join(', \n'));
@@ -1002,6 +1006,12 @@ AppBackend.prototype.dumpDbSchema = function dumpDbSchema(){
                 );
             });
             lines.push(tableDef.sql.postCreateSqls);
+            lines.push('');
+            fieldsForSequences.forEach(function(field) {
+                var sequenceName = 'seq_'+field.name;
+                lines.push("CREATE SEQUENCE "+sequenceName+" START "+field.sequenceFirstValue+"; ALTER TABLE "+tableName+" ALTER COLUMN "+field.name+" SET DEFAULT ('"+field.prefix+"' || nextval('"+sequenceName+"'::regclass)::text);");
+                lines.push('GRANT USAGE, SELECT ON SEQUENCE '+sequenceName+' TO '+admin+';');
+            });
             lines.push('');
         }
     }

--- a/lib/table-def-adapt.js
+++ b/lib/table-def-adapt.js
@@ -67,8 +67,13 @@ function tableDefAdapt(tableDef, context){
         var resultFieldDef = changing({
             allow:{},
             defaultForOtherFields: false,
+            generateSequence: false, 
             title: fieldDef.name.replace(prefixRegExp,'').replace(/_/g, ' '),
         }, fieldDef);
+        if (resultFieldDef.generateSequence){
+            resultFieldDef.sequenceFirstValue = resultFieldDef.sequenceFirstValue || 1;
+            resultFieldDef.prefix = resultFieldDef.prefix || '';
+        }
         typeStore.completeTypeInfo(resultFieldDef);
         resultFieldDef.label = resultFieldDef.label||resultFieldDef.title;
         completeEditablesProperties(resultFieldDef, !!resultTableDef.editableFieldDef, resultTableDef.allow);


### PR DESCRIPTION
this feature enable the user to define sequences for his table fields.
Usage:
fields:[
            {name:'gender'          , typeName:'text'     ,title:'Gender' , generateSequence: true, sequenceFirstValue: 1, prefix: 'notif-'},
...
default values:
generateSequence -> false, 

default values when generateSequence == true:
sequenceFirstValue -> 1, 
prefix -> '' (empty string)